### PR TITLE
Allow window_threshold to be non-integer

### DIFF
--- a/R/NetworkBuilding.R
+++ b/R/NetworkBuilding.R
@@ -209,7 +209,7 @@ edgelist_from_base <- function(base,
     checks = makeAssertCollection()
     assertDataFrame(base, add = checks)
     assertTRUE(ncol(base) >= 4, add = checks)
-    assertCount(window_threshold, add = checks)
+    assertNumber(window_threshold, lower = 0, add = checks)
     assertChoice(count_option, c("all", "successive"), add = checks)
     assertLogical(noloops, add = checks)
     assertCount(nmoves_threshold, null.ok = T, add = checks)

--- a/tests/testthat/test-NetworkBuilding.R
+++ b/tests/testthat/test-NetworkBuilding.R
@@ -209,3 +209,12 @@ test_that("matrix_from_base() computes the right matrix", {
     expect_equal(c(mC["f1", "f2"], mC["f2", "f3"], mC["f3", "f4"]), c(6, 1, 1))
 })
 
+test_that("non-integer window threshold gives the same as integer", {
+    minteger = matrix_from_base(checkBase(base),
+                                window_threshold = 1)
+    mnoninteger = matrix_from_base(checkBase(base),
+                                   window_threshold = 1.5)
+    
+    expect_equal(minteger, mnoninteger)
+})
+


### PR DESCRIPTION
`window_threshold` had an assertion to be integer-ish. `between` will take non-integer arguments with no issues and can be useful if you have more than daily precision in data.